### PR TITLE
Fixing issue #26 : Adding an automation for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,44 @@
+name: 🐞 Bug Report
+description: File a bug report
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Add descriptions
+      value: 'I found a BUG 🐞'
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Add screenshots to see the problems
+      placeholder: Add screenshots
+      value: 'Add screenshots'
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Brave
+        - Other
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,32 @@
+name: 🔖 Documentation update
+description: Improve Documentation
+title: '[Docs]: '
+labels: ['documentation']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this documentation update template!
+  - type: textarea
+    id: improve-docs
+    attributes:
+      label: what's wrong in the documentation?
+      description: which things need to add?
+      placeholder: Add descriptions
+      value: 'We need to add '
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Add screenshots to see the demo
+      placeholder: Add screenshots
+      value: 'Add screenshots'
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,31 @@
+name: ✨ Feature Request
+description: Suggest a feature request
+title: '[Feat]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request template!
+  - type: textarea
+    id: what-feature
+    attributes:
+      label: What feature?
+      placeholder: Add descriptions
+      value: 'I have an idea '
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Add screenshots to see the demo
+      placeholder: Add screenshots
+      value: 'Add screenshots'
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct

--- a/.github/ISSUE_TEMPLATE/style.yml
+++ b/.github/ISSUE_TEMPLATE/style.yml
@@ -1,0 +1,31 @@
+name: 🔥 Style Changing Request
+description: Suggest a style designs
+title: '[style]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this template!
+  - type: textarea
+    id: style-idea
+    attributes:
+      label: What's the style idea?
+      placeholder: Add descriptions
+      value: 'We need to improve  '
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Add screenshots to see the demo
+      placeholder: Add screenshots
+      value: 'Add screenshots'
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct


### PR DESCRIPTION
## Description

Add automation Github Actions for issues

## Related Issues
Fixes : #26 

## Changes Proposed
Incorporate automation into the issue creation process, so that when contributors create a new issue, they can choose an issue type, and a template will be automatically generated based on their selection.

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/DevSoc-Asansol2023/DevSoc-Main/blob/main/Contributing.md).
- [x] All new and existing tests passed.
- [ ] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.
- [ ] I have shared relevant screenshots or videos for both desktop and mobile view.

## Screenshots/video/urls

## Note to reviewers
